### PR TITLE
Fix bug in BLAST results parsing when taxonomic name contains (

### DIFF
--- a/scripts/blast/blast-16S-MiFish.py
+++ b/scripts/blast/blast-16S-MiFish.py
@@ -166,7 +166,7 @@ def process_blast_output(out_file, database):
                 taxa_list.append(tax)
 
             else:
-                tax = hit.split('|')[2].split('(')[0].strip()
+                tax = hit.split('|')[2].split('([')[0].strip()
                 taxa_list.append(tax)
 
         blast_mifish['taxa'] = taxa_list


### PR DESCRIPTION
For some more complicated taxonomic names pytaxonkit returns nothing, leading to missed lines when merging the pytaxonkit and the blast results.

This is the offending line:

    tax = hit.split('|')[2].split('(')[0].strip()

this was written with lines like _Tor khudree (["Cypriniformes;"] ["Cyprinidae;"])_ in mind, splitting on the ( and pulling out the taxonomic name, but once you have ( in the taxonomy name itself you have problems: 

_(Megalobrama amblycephala x Megalobrama terminalis) x (Megalobrama amblycephala x Megalobrama terminalis) ([""Cypriniformes;""] [""Cyprinidae;""])"_

for example, when we split by ( we land 'before' the taxonomic name. The laziest workaround is to split on '([' instead, which is what this PR does.

 

Laziest workaround is adding a [ to the splitting:

tax = hit.split('|')[2].split('([')[0].strip()