### PR TITLE
Document taxonomy db

### DIFF
--- a/scripts/07-run_LCA.sh
+++ b/scripts/07-run_LCA.sh
@@ -69,7 +69,3 @@ for a in ${assay[@]}
   done
 
 fi
-
-# clean up intermediate files
-rm interMediate_res.tab
-find . -maxdepth 1 -mindepth 1 -name '*taxdump' -type d -exec rm -r {} \;

--- a/scripts/LCA/runAssign_collapsedTaxonomy.py
+++ b/scripts/LCA/runAssign_collapsedTaxonomy.py
@@ -6,6 +6,8 @@
 # Then it will link it to an NCBI taxonomy file and Zotu/Otu table file
 
 # By Mahsa Mousavi-Derazmahalleh ; Python V3
+# Slightly amended by Sebastian Rauschert and Philipp Bayer to retain downloaded taxdump for
+# reproducibility purposes
 
 import subprocess
 import sys
@@ -14,16 +16,20 @@ import working_function as wf
 
 # define commands for downloading taxonomy database from NCBI and saving it in a folder with the current date
 # if folder exists, it overwrites it
+
+# also keep track of taxdump metadata in the logs folder
 getLineage = '''
 d="$(date +"%d-%m-%Y")" 
+rm -rf ${d}_taxdump
 mkdir ${d}_taxdump
 cd ${d}_taxdump 
 wget ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/new_taxdump/new_taxdump.zip 
 unzip new_taxdump.zip 
+wc -l *dmp > ../logs/07-run_LCA_taxdump_linecounts.log
+md5sum *dmp > ../logs/07-run_LCA_taxdump_md5sums.log
 mv rankedlineage.dmp ..  
 cd .. 
 tr -d "\t" < rankedlineage.dmp > rankedlineage_tabRemoved.dmp 
-rm -f ${d}_taxdump/*
 rm -f rankedlineage.dmp
 '''
 
@@ -143,8 +149,8 @@ sys.stdout = def_output
 
 # cleaning up temporary files
 cmd = '''
-d="$(date +"%d-%m-%Y")"
-mv rankedlineage_tabRemoved.dmp ${d}_taxdump
+rm rankedlineage_tabRemoved.dmp
+rm interMediate_res.tab
 '''
 process = subprocess.Popen('/bin/bash', stdin=subprocess.PIPE,
                            stdout=subprocess.PIPE, universal_newlines=True)


### PR DESCRIPTION
Some slight changes to Mahsa's taxonomy script that document line counts and md5sums for the downloaded taxonomy DB. I also changed the same script's cleanup operation, it used to delete the downloaded taxdump, but I believe that retaining the downloaded taxonomy data will help with reproducibility (future changes in the downloaded taxdump will change the resulting LCAs). 

I've also cleaned up the README slightly, I made all folders and commands look like `this` and removed the obsolete taxonkit download instructions as we're not using 'my' computeLCA.py script.